### PR TITLE
fix: include org on the namespace

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: "Publish"
         uses: devcontainers/action@v1
         with:
-          templates-namespace: "devcontainers"
+          templates-namespace: "the-nefarious-developer/devcontainers"
           publish-templates: "true"
           base-path-to-templates: "./src"
         env:

--- a/src/sap-cap-javascript-node/devcontainer-template.json
+++ b/src/sap-cap-javascript-node/devcontainer-template.json
@@ -2,7 +2,7 @@
     "id": "sap-cap-javascript-node",
     "version": "1.0.0",
     "name": "SAP CAP",
-    "description": "Develop CAP based projects for SAP BTP Cloud Foundry.",
+    "description": "Develop CAP based projects with Node.js for SAP BTP Cloud Foundry.",
     "documentationURL": "https://github.com/The-Nefarious-Developer/devcontainer-templates/tree/main/src/sap-cap-javascript-node",
     "publisher": "The Nefarious Developer",
     "licenseURL": "https://github.com/The-Nefarious-Developer/devcontainer-templates/blob/main/LICENSE",


### PR DESCRIPTION
If the namespace is defined in the action to publish, the org and repo name are ignored, thus the org needs to be manually included.