### PR TITLE
Fix pipeline and trigger publishing job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ jobs:
         with:
           publish-templates: "true"
           base-path-to-templates: "./src"
-          generate-docs: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.NEFARIOUS_TOKEN }}
         


### PR DESCRIPTION
The publishing action wasn't able to automatically associate the created devcontainer template package to the repository. A manual action to link it and make it public will be necessary.